### PR TITLE
Make this build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ dist: trusty
 
 install:
   - sudo add-apt-repository -y ppa:cwchien/gradle && sudo apt-get update && sudo apt-get install -qq gradle-2.9
-  - gradle dependencies > /dev/null
+  - gradle dependencies | stdbuf -o0 sed 's/.*/./g' | stdbuf -o0 tr -d '\n'; echo
   - ./buildSrc/src/deploy/bash/Install\ Doc.sh
   
 script:

--- a/buildSrc/src/tasks/gradle/20 eclipse.gradle
+++ b/buildSrc/src/tasks/gradle/20 eclipse.gradle
@@ -31,11 +31,11 @@ configure(eclipseSubprojects) {
 	apply plugin: DownloadTaskPlugin
 	
 	def lister = new ApacheURLLister()
-	def downloadUpdatesite
 	
 	/**
 	 * Recursivly downloads an update site.
 	 */
+	def downloadUpdatesite
 	downloadUpdatesite = { URL url, destinationDir ->
 		file(destinationDir).mkdirs()
 		project.download {
@@ -47,7 +47,7 @@ configure(eclipseSubprojects) {
 			downloadUpdatesite folder, "$destinationDir/$destPart" 
 		}
 	}
-
+	
 	/**
 	 * Downloads an update site and provides a path to it to be used by wuff.
 	 * 
@@ -77,10 +77,11 @@ configure(eclipseSubprojects) {
 		eclipseVersion('4.5') {
 			sources {
 				/*
-				 * Configure all update sites to get dependency plugins from here.
+				 * Define the needed update sites for ALL projects here!
 				 */
-				source updatesite("https://sdqweb.ipd.kit.edu/eclipse/palladiosimulator/nightly/aggregate/")
+				source updatesite('https://sdqweb.ipd.kit.edu/eclipse/palladiosimulator/nightly/aggregate/') // PCM
+				source updatesite('http://ftp-stud.fht-esslingen.de/pub/Mirrors/eclipse/modeling/gmp/updates/releases/') // required by Context Menu Prototype
 			}
 		}
-	}
+	} 
 }


### PR DESCRIPTION
Luckily, there exist a lot of mirrors for the gmp update sites, and these mirrors behave like my code expects it. Now we have a mirror from my hometown :)

I additionally adapted the Travis build script. Downloading the dependencies now takes over 8 minutes, so we output dots to show Travis we’re still working (printing the full log would cause Travis to not show us the log at all because it’s to long).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/romanlangrehr/beagle/7)

<!-- Reviewable:end -->
